### PR TITLE
Allow NUM_TLCS to be specified with compile flags

### DIFF
--- a/tlc_config.h
+++ b/tlc_config.h
@@ -52,7 +52,9 @@
     of the first TLC to the SIN (TLC pin 26) of the next.  The rest of the pins
     are attached normally.
     \note Each TLC needs it's own IREF resistor */
+#ifndef NUM_TLCS
 #define NUM_TLCS    1
+#endif
 
 /** Determines how data should be transfered to the TLCs.  Bit-banging can use
     any two i/o pins, but the hardware SPI is faster.


### PR DESCRIPTION
This change allows the number of TLCs that are controlled to be specified by compiler flag, so it can be set at compile time when using platformio and similar build systems.
