### PR TITLE
Updated Servo H, changed int type

### DIFF
--- a/tlc_servos.h
+++ b/tlc_servos.h
@@ -133,7 +133,7 @@ uint8_t tlc_getServo(TLC_CHANNEL_TYPE channel)
 uint16_t tlc_angleToVal(uint8_t angle)
 {
     return 4095 - SERVO_MIN_WIDTH - (
-            ((uint16_t)(angle) * (uint16_t)(SERVO_MAX_WIDTH - SERVO_MIN_WIDTH))
+            ((uint16_t)(angle) * (uint32_t)(SERVO_MAX_WIDTH - SERVO_MIN_WIDTH))
             / SERVO_MAX_ANGLE);
 }
 


### PR DESCRIPTION
made uint16 into uint32 to account for integer overflow of function (angle) * (SERVO_MAX_WIDTH - SERVO_MIN_WIDTH), when given a sufficiently large range. 
Previously, the limit of Delta from MAX WIDTH and MIN WIDTH is 364 (364*180 = 65520). Increasing delta will cause overflow.
Previously, the total Delta was limited to the around a 1.78 ms range of sendable values: i.e. 1.5 +/- .892 ( 0.607 - 2.392 ).