### PR TITLE
Add constant for Teensy 3.6

### DIFF
--- a/pinouts/chip_includes.h
+++ b/pinouts/chip_includes.h
@@ -113,9 +113,10 @@
 #include "Teensypp_xxx6.h"
 
 #elif defined (__MK20DX128__) \
-   || defined (__MK20DX256__)
+   || defined (__MK20DX256__) \
+   || defined (__MK66FX1M0__)
 
-/* Teensy 3.0 & 3.1 */
+/* Teensy 3.0 & 3.1 & 3.6*/
 #include "Teensy_KinetisK20.h"
 
 


### PR DESCRIPTION
It compiles fine and have tested with the libraries 'basicUse' example, which seemed to work fine.
I could assume Teensy 3.5 support is just as easy, however i have no way to test.