### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,41 +6,41 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Tlc5940         KEYWORD1
+Tlc5940	        KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init            KEYWORD2
-clear           KEYWORD2
-update          KEYWORD2
-set             KEYWORD2
-get             KEYWORD2
-setAll          KEYWORD2
-setAllDC        KEYWORD2
-readXERR        KEYWORD2
-tlc_setGSfromProgmem    KEYWORD2
-tlc_setDCfromProgmem    KEYWORD2
-tlc_playAnimation       KEYWORD2
-tlc_addFade             KEYWORD2
-tlc_removeFade          KEYWORD2
-tlc_shiftUp             KEYWORD2
-tlc_shiftDown           KEYWORD2
+init	          KEYWORD2
+clear	          KEYWORD2
+update	        KEYWORD2
+set	            KEYWORD2
+get	            KEYWORD2
+setAll	        KEYWORD2
+setAllDC	      KEYWORD2
+readXERR	      KEYWORD2
+tlc_setGSfromProgmem	  KEYWORD2
+tlc_setDCfromProgmem	  KEYWORD2
+tlc_playAnimation	      KEYWORD2
+tlc_addFade	            KEYWORD2
+tlc_removeFade	        KEYWORD2
+tlc_shiftUp	            KEYWORD2
+tlc_shiftDown	          KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-Tlc             KEYWORD2
+Tlc	            KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-NUM_TLCS        LITERAL1
-tlc_needXLAT    LITERAL1
-tlc_GSData      LITERAL1
-tlc_onUpdateFinished    LITERAL1
-TLC_FADE_BUFFER_LENGTH  LITERAL1
-tlc_fadeBufferSize      LITERAL1
+NUM_TLCS	      LITERAL1
+tlc_needXLAT	  LITERAL1
+tlc_GSData	    LITERAL1
+tlc_onUpdateFinished	  LITERAL1
+TLC_FADE_BUFFER_LENGTH	LITERAL1
+tlc_fadeBufferSize	    LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords