### PR TITLE
Remove leading space from keywords.txt identifier tokens

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,41 +6,41 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Tlc5940	        KEYWORD1
+Tlc5940	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init	          KEYWORD2
-clear	          KEYWORD2
-update	        KEYWORD2
-set	            KEYWORD2
-get	            KEYWORD2
-setAll	        KEYWORD2
-setAllDC	      KEYWORD2
-readXERR	      KEYWORD2
-tlc_setGSfromProgmem	  KEYWORD2
-tlc_setDCfromProgmem	  KEYWORD2
-tlc_playAnimation	      KEYWORD2
-tlc_addFade	            KEYWORD2
-tlc_removeFade	        KEYWORD2
-tlc_shiftUp	            KEYWORD2
-tlc_shiftDown	          KEYWORD2
+init	KEYWORD2
+clear	KEYWORD2
+update	KEYWORD2
+set	KEYWORD2
+get	KEYWORD2
+setAll	KEYWORD2
+setAllDC	KEYWORD2
+readXERR	KEYWORD2
+tlc_setGSfromProgmem	KEYWORD2
+tlc_setDCfromProgmem	KEYWORD2
+tlc_playAnimation	KEYWORD2
+tlc_addFade	KEYWORD2
+tlc_removeFade	KEYWORD2
+tlc_shiftUp	KEYWORD2
+tlc_shiftDown	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-Tlc	            KEYWORD2
+Tlc	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-NUM_TLCS	      LITERAL1
-tlc_needXLAT	  LITERAL1
-tlc_GSData	    LITERAL1
-tlc_onUpdateFinished	  LITERAL1
+NUM_TLCS	LITERAL1
+tlc_needXLAT	LITERAL1
+tlc_GSData	LITERAL1
+tlc_onUpdateFinished	LITERAL1
 TLC_FADE_BUFFER_LENGTH	LITERAL1
-tlc_fadeBufferSize	    LITERAL1
+tlc_fadeBufferSize	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3, LITERAL2).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords